### PR TITLE
Tweak Multiplicador de Eventos

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -95,20 +95,22 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	else
 		var/playercount_modifier = 1
 		switch(GLOB.player_list.len)
-			if(0 to 10)
+		///HISPANIA STARTS HERE
+			if(0 to 5)
 				playercount_modifier = 1.2
-			if(11 to 15)
+			if(6 to 12)
 				playercount_modifier = 1.1
-			if(16 to 25)
+			if(13 to 16)
 				playercount_modifier = 1
-			if(26 to 35)
+			if(17 to 18)
 				playercount_modifier = 0.9
-			if(36 to 50)
+			if(19 to 25)
 				playercount_modifier = 0.8
-			if(50 to 80)
+			if(26 to 30)
 				playercount_modifier = 0.7
-			if(80 to 10000)
+			if(30 to 10000)
 				playercount_modifier = 0.6
+			///HISPANIA ENDS HERE
 
 		playercount_modifier = playercount_modifier * delay_modifier
 


### PR DESCRIPTION
## What Does This PR Do
Modifica el multiplicador de eventos para numero total de jugadores en metas que actualmente alcanzamos de forma constante.

## Why It's Good For The Game
Proporciona metas realistas para el multiplicador y de esta forma pueda alcanzar un ciclo constante de eventos aleatorios en base a números constantes que se alcanzan en el servidor, anteriormente se encontraba fijado para una top player base de 80 jugadores con esto bajamos ese limite a alcanzar para 30 jugadores de esta forma mas eventos aleatorios suceden de forma constante en base a el top de jugadores que hay en el server, esperamos asi se pueda divertir mas la gente disfrutando de los múltiples eventos que se ofrecen.

El tiempo entre eventos se calcula en una multiplicación de un numero aleatorio generado entre los limites de EVENT_DELAY_LOWER y EVENT_DELAY_UPPER (estos dos valores se definen dentro del archivo base de config) por playercount_modifier (numero que escala en base a pop del server). Donde en cada caso de EVENT_DELAY_LOWER y EVENT_DELAY_UPPER se modifica en base a la severidad de los 3 valores existentes Mundane, Moderate y Severe Esto se representa como:

event_delay = rand(config.event_delay_lower[severity], config.event_delay_upper[severity]) * playercount_modifier

## Changelog
:cl:
tweak: Multiplicador de eventos
/:cl:
