### PR TITLE
Webhooks para Notas y Bans

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -510,6 +510,12 @@
 /// Send to the mentor Discord webhook
 #define DISCORD_WEBHOOK_MENTOR "MENTOR"
 
+/// Send to the bans Discord webhook
+#define DISCORD_WEBHOOK_BANS "BANS"
+
+/// Send to the notes Discord webhook
+#define DISCORD_WEBHOOK_NOTES "NOTES"
+
 // Hallucination severities
 #define HALLUCINATE_MINOR 1
 #define HALLUCINATE_MODERATE 2

--- a/code/controllers/configuration/sections/discord_configuration.dm
+++ b/code/controllers/configuration/sections/discord_configuration.dm
@@ -18,6 +18,12 @@
 	var/list/mentor_webhook_urls = list()
 	/// List of all URLs for the mentor webhooks
 	var/list/admin_webhook_urls = list()
+	/// HISPANIA START
+	/// Lista de URLS para el webhook de bans
+	var/list/bans_webhook_urls = list()
+	/// Lista de URLS para el webhook de notas
+	var/list/notes_webhook_urls = list()
+	/// HISPANIA END
 
 
 
@@ -33,3 +39,7 @@
 	CONFIG_LOAD_LIST(main_webhook_urls, data["main_webhook_urls"])
 	CONFIG_LOAD_LIST(mentor_webhook_urls, data["mentor_webhook_urls"])
 	CONFIG_LOAD_LIST(admin_webhook_urls, data["admin_webhook_urls"])
+	/// HISPANIA START
+	CONFIG_LOAD_LIST(bans_webhook_urls, data["bans_webhook_urls"])
+	CONFIG_LOAD_LIST(notes_webhook_urls, data["notes_webhook_urls"])
+	/// HISPANIA END

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -43,6 +43,10 @@ SUBSYSTEM_DEF(discord)
 			webhook_urls = GLOB.configuration.discord.main_webhook_urls
 		if(DISCORD_WEBHOOK_MENTOR)
 			webhook_urls = GLOB.configuration.discord.mentor_webhook_urls
+		if(DISCORD_WEBHOOK_BANS)
+			webhook_urls = GLOB.configuration.discord.bans_webhook_urls
+		if(DISCORD_WEBHOOK_NOTES)
+			webhook_urls = GLOB.configuration.discord.notes_webhook_urls
 	for(var/url in webhook_urls)
 		SShttp.create_async_request(RUSTG_HTTP_METHOD_POST, url, dwp.serialize2json(), list("content-type" = "application/json"))
 

--- a/code/modules/admin/db_ban/functions.dm
+++ b/code/modules/admin/db_ban/functions.dm
@@ -1,4 +1,4 @@
-#define MAX_ADMIN_BANS_PER_ADMIN 1
+	#define MAX_ADMIN_BANS_PER_ADMIN 1
 
 /datum/admins/proc/DB_ban_record(bantype, mob/banned_mob, duration = -1, reason, job = "", rounds = 0, banckey = null, banip = null, bancid = null)
 
@@ -427,6 +427,7 @@
 
 	message_admins("[key_name_admin(usr)] has lifted [pckey]'s ban.")
 	log_admin("[key_name(usr)] has lifted [pckey]'s ban.")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] removió el ban de [pckey]")
 	flag_account_for_forum_sync(pckey)
 	// See if they are online
 	var/client/C = GLOB.directory[ckey(pckey)]

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -84,6 +84,7 @@
 	if(logged)
 		log_admin("[usr ? key_name(usr) : adminckey] has added a note to [target_ckey]: [notetext]")
 		message_admins("[usr ? key_name_admin(usr) : adminckey] has added a note to [target_ckey]:<br>[notetext]")
+		SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] agregó una nota al jugador [target_ckey]: \n[notetext]")
 		if(show_after)
 			show_note(target_ckey)
 
@@ -124,6 +125,7 @@
 
 	log_admin("[usr ? key_name(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]: [safe_text]")
 	message_admins("[usr ? key_name_admin(usr) : "Bot"] has removed a note made by [adminckey] from [ckey]:<br>[safe_text]")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] removió una nota hecha por [adminckey] al jugador [ckey]: \n[notetext]")
 	show_note(ckey)
 
 /proc/edit_note(note_id)
@@ -169,6 +171,7 @@
 			return
 		log_admin("[usr ? key_name(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[safe_text]\"")
 		message_admins("[usr ? key_name_admin(usr) : "Bot"] has edited [target_ckey]'s note made by [adminckey] from \"[old_note]\" to \"[safe_text]\"")
+		SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] editó una nota hecha por [adminckey] al jugador [target_ckey]: \n[old_note] \n\nNueva nota: \n[safe_text]")
 		show_note(target_ckey)
 		qdel(query_update_note)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -746,6 +746,8 @@
 							msg += ", [job]"
 					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
 					message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [mins] minutes</span>", 1)
+					SSdiscord.send2discord_simple(DISCORD_WEBHOOK_BANS, "[usr.ckey] jobbaneó a [key_name_admin(M)] de [msg]: \n\n[reason] \n\nEste jobban será removido en [mins] minutos")
+					SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] jobbaneó a [key_name_admin(M)] de [msg]: \n\n[reason] \n\nEste jobban será removido en [mins] minutos")
 
 					// Reload their job ban holder (refresh this round)
 					if(M.client)
@@ -769,6 +771,8 @@
 								msg += ", [job]"
 						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
 						message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg]</span>", 1)
+						SSdiscord.send2discord_simple(DISCORD_WEBHOOK_BANS, "[usr.ckey] jobbaneó a [key_name_admin(M)] de [msg]: \n\n[reason] \n\nEste jobban no será removido automáticamente y debe ser apelado de ser posible.")
+						SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] jobbaneó a [key_name_admin(M)] de [msg]: \n\n[reason] \n\nEste jobban no será removido automácode/modules/admin/db_ban/functions.dmticamente y debe ser apelado de ser posible.")
 
 						// Reload their job ban holder (refresh this round)
 						if(M.client)
@@ -892,6 +896,8 @@
 					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
 				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
 				message_admins("<span class='notice'>[key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_BANS, "[usr.ckey] baneó a [M.ckey] por: \n\n[reason] \n\nEste ban será removido en [mins] minutos")
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] baneó a [M.ckey] por: \n\n[reason] \n\nEste ban será removido en [mins] minutos")
 
 				qdel(M.client)
 			if("No")
@@ -908,6 +914,8 @@
 					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
 				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis ban does not expire automatically and must be appealed.")
 				message_admins("<span class='notice'>[key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis ban does not expire automatically and must be appealed.</span>")
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_BANS, "[usr.ckey] baneó a [M.ckey] por: \n\n[reason] \n\nEste ban no es temporal y debe ser apelado de ser posible.")
+				SSdiscord.send2discord_simple(DISCORD_WEBHOOK_NOTES, "[usr.ckey] baneó a [M.ckey] por: \n\n[reason] \n\nEste ban no es temporal y debe ser apelado de ser posible.")
 				DB_ban_record(BANTYPE_PERMA, M, -1, reason)
 				add_note(M.ckey, "Permanently banned - [reason]", null, usr.ckey, FALSE)
 

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -185,6 +185,16 @@ admin_webhook_urls = [
 	"https://admin.webhook.one",
 	"https://admin.webhook.two"
 ]
+# HISPANIA - Lista de todas las URLs para el webhook de bans
+bans_webhook_urls = [
+	"https://bans.webhook.one",
+	"https://bans.webhook.two"
+]
+# HISPANIA - Lista de todas las URLs para el webhook de notas
+notes_webhook_urls = [
+	"https://notes.webhook.one",
+	"https://notes.webhook.two"
+]
 # Role ID for the admin role on the discord. Set to "" to disable.
 # THESE MUST BOTH BE STRINGS. BYOND DOESNT LIKE NUMBERS THIS BIG
 admin_role_id = ""


### PR DESCRIPTION
# Que hace este PR
Este PR crea 2 nuevos webhooks, el de Bans y el de Notas.

El webhook de bans enviara todos los baneos al canal que se le asigne por medio del url del webhook. En el contenido del mensaje se encontrara el autor del ban, la razón y el usuario que fue baneado, así como su duración en el caso de que no sea permanente.

El webhook de notas enviara mensajes cada vez que se cree, elimine o edite una nota en el servidor, así como el autor de esta, el contenido y el usuario objetivo.

# Por que es bueno este PR
En el canal de baneos podemos ~reírnos de la miseria de otros~ enterarnos quien fue baneado,  mientras que el de notas permite que los admins estén al tanto de lo que sucede en el servidor.

Es posible configurar estos webhooks mediante el archivo .txt o .toml

PD: No fui capaz de testear esto ya que necesito una base de datos pero fueron creados en base al código de los otros webhooks asi que en teoría, deberían de funcionar bien.