### PR TITLE
Los borgs ahora pueden interactuar con los tank dispenser

### DIFF
--- a/modular_hispania/code/game/objects/structures/tank_dispenser.dm
+++ b/modular_hispania/code/game/objects/structures/tank_dispenser.dm
@@ -1,0 +1,4 @@
+/obj/structure/dispenser/attack_ai(mob/user as mob)
+	if(isrobot(user))
+		ui_interact(user)
+	return

--- a/paradise.dme
+++ b/paradise.dme
@@ -2647,6 +2647,7 @@
 #include "modular_hispania\code\game\objects\items\weapons\manuals.dm"
 #include "modular_hispania\code\game\objects\items\weapons\storage\belt.dm"
 #include "modular_hispania\code\game\objects\items\weapons\storage\garment.dm"
+#include "modular_hispania\code\game\objects\structures\tank_dispenser.dm"
 #include "modular_hispania\code\modules\clothing\clothing.dm"
 #include "modular_hispania\code\modules\clothing\gloves\color.dm"
 #include "modular_hispania\code\modules\clothing\head\helmets.dm"


### PR DESCRIPTION
Anteriormente no podian. Esto facilita tareas y no tenia mucho sentido que no pudiesen sacar los tanques de oxigeno o de plasma cuando su gripper siempre les permitio tomarlos

![image](https://user-images.githubusercontent.com/24284918/211741384-9c9a755d-cae9-46f8-aac9-a2b7ee121412.png)
