### PR TITLE
Agrega el Halt security

### DIFF
--- a/modular_hispania/code/game/machinery/vending.dm
+++ b/modular_hispania/code/game/machinery/vending.dm
@@ -26,3 +26,11 @@
 					/obj/item/clothing/under/rank/security/detective/fem = 50,
 					/obj/item/clothing/suit/storage/det_suit/forensics/black = 75,
 					/obj/item/clothing/head/det_hat/black = 20)
+
+/obj/machinery/economy/vending/security
+	hispa_products = list(
+					/obj/item/hailer = 1
+					)
+	hispa_prices = list(
+					/obj/item/hailer = 100
+					)


### PR DESCRIPTION
Un dispositivo que hace el ruidito de HALT SECURITY. Por algun motivo los de para se olvidaron de agregarlo ala vending porque ya existe en el codigo.  Cuesta100 creditos ya que no es algo imprescindible pero es divertido de usar

![image](https://user-images.githubusercontent.com/24284918/212156546-5a53ef1d-410e-49f1-996b-34071c24e88a.png)

