### PR TITLE
NO MAS MENCIONES SI NO HAY ADMINS AL INICIAR UNA RONDA.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -307,7 +307,7 @@ SUBSYSTEM_DEF(ticker)
 			var/datum/holiday/holiday = SSholiday.holidays[holidayname]
 			to_chat(world, "<h4>[holiday.greet()]</h4>")
 
-	SSdiscord.send2discord_simple_noadmins("**\[Info]** Round has started")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_ADMIN ,"**\[Info]** Round has started")
 	auto_toggle_ooc(FALSE) // Turn it off
 	time_game_started = world.time
 


### PR DESCRIPTION
## What Does This PR Do
El bot ya no menciona al staff cuando inicia una ronda sin admins online.

El staff ya no va a ser mencionado 300 veces al día.
