### PR TITLE
Nuevo random event  moderate emergency access

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -186,7 +186,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Door Runtime",				/datum/event/door_runtime,				50,		list(ASSIGNMENT_ENGINEER = 25, ASSIGNMENT_AI = 150), TRUE),
 
 		//HISPANIA CHANGES START
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Feed me",					/datum/event/feedme, 					0,		list(ASSIGNMENT_SERVICE = 10))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Feed me",					/datum/event/feedme, 					0,		list(ASSIGNMENT_SERVICE = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "All acces",				/datum/event/all_access, 				75,		list(ASSIGNMENT_SECURITY = 100)),
 		//HISPANIA CHANGES END
 	)
 

--- a/modular_hispania/code/modules/events/all_acces.dm
+++ b/modular_hispania/code/modules/events/all_acces.dm
@@ -1,0 +1,19 @@
+/datum/event/all_access
+	announceWhen = 3
+	endWhen = 60
+
+/datum/event/all_access/start()
+	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
+		if(is_station_level(D.z))
+			D.emergency = 1
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Los accesos de [station_name()] estan teniendo dificultades tecnicas. Porfavor mantengan la calma mientras se reestablecen")
+	GLOB.station_all_access = 1
+
+/datum/event/all_access/end()
+	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
+		if(is_station_level(D.z))
+			D.emergency = 0
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Los accesos ya funcionan con normalidad. Muchas gracias")
+	GLOB.station_all_access = 0

--- a/modular_hispania/code/modules/events/all_acces.dm
+++ b/modular_hispania/code/modules/events/all_acces.dm
@@ -1,6 +1,6 @@
 /datum/event/all_access
 	announceWhen = 3
-	endWhen = 60
+	endWhen = 40
 
 /datum/event/all_access/start()
 	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)

--- a/paradise.dme
+++ b/paradise.dme
@@ -2688,6 +2688,7 @@
 #include "modular_hispania\code\modules\clothing\under\jobs\medsci.dm"
 #include "modular_hispania\code\modules\clothing\under\jobs\security.dm"
 #include "modular_hispania\code\modules\crafting\recipes.dm"
+#include "modular_hispania\code\modules\events\all_acces.dm"
 #include "modular_hispania\code\modules\events\feedme.dm"
 #include "modular_hispania\code\modules\food_and_drinks\condiments.dm"
 #include "modular_hispania\code\modules\food_and_drinks\drinks\bottle.dm"


### PR DESCRIPTION
Evento moderado nuevo all acces

- Se anuncia que hay dificultades tecnicas con los accesos
- Las puertas son puestas en modo emergencia por 1 minuto
- Requiere de seguridad para tener mas chances deq salga el  random event

Anteriormente existia un evento que se cortaba toda la luz de la estacion y se abrian las puertas. Eso fue reemplazado por el short APCS.  este evento viene a cubrir ese nicho