### PR TITLE
Saca al vox armalis de especies

### DIFF
--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -144,7 +144,7 @@
 
 	eyes = "blank_eyes"
 
-	species_traits = list(NO_CLONESCAN, NO_BLOOD, IS_WHITELISTED)
+	species_traits = list(NO_CLONESCAN, NO_BLOOD) //Hispania Changes Start & End
 	inherent_traits = list(TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE, TRAIT_NOFIRE, TRAIT_NOPAIN, TRAIT_NOGERMS, TRAIT_NODECAY)
 	clothing_flags = 0 //IDK if you've ever seen underwear on an Armalis, but it ain't pretty.
 	bodyflags = HAS_TAIL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Mata al vox armalis de una vez por todas.
No aparecera mas en la lista de especies al crear un personaje.
![image](https://user-images.githubusercontent.com/94068050/214113539-0abae83f-3c44-4e5c-bd1c-60c934312de2.png)
