### PR TITLE
Cambio en las votaciones

### DIFF
--- a/code/modules/vote/vote_datum.dm
+++ b/code/modules/vote/vote_datum.dm
@@ -10,7 +10,7 @@
 	/// Vote type text, for showing in UIs and stuff
 	var/vote_type_text = "unset"
 	/// Do we want to show the vote counts as it goes
-	var/show_counts = FALSE
+	var/show_counts = TRUE		//HISPANIA CHANGES START & END HERE
 	/// Vote result type. This determines how a winner is picked
 	var/vote_result_type = VOTE_RESULT_TYPE_MAJORITY
 	/// Was this vote custom started?
@@ -193,6 +193,10 @@
 	switch(action)
 		if("vote")
 			if(params["target"] in choices)
+				//HISPANIA CHANGES START
+				if(!(usr.ckey in voted))
+					to_chat(world, "Un usuario ha votado por [params["target"]]")
+				//HISPANIA CHANGES END
 				voted[usr.ckey] = params["target"]
 			else
 				message_admins("<span class='boldannounce'>\[EXPLOIT]</span> User [key_name_admin(usr)] spoofed a vote in the vote panel!")


### PR DESCRIPTION
Es una queja comun que la gente se olvida de votar. Con suerte esto deberia ayudar a que vote mas gente el crew transfer. La cantidad de votos ahora es visible y se manda un mensaje cada vez que alguien voto.   Para prevenir el SPAM solo se envia la primera vez q se selecciono