### PR TITLE
Codigo azul para heads

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -94,7 +94,7 @@
 		var/list/access = usr.get_access()
 		if(allowed(usr))
 			authenticated = COMM_AUTHENTICATION_HEAD
-		if(ACCESS_CAPTAIN in access)
+		if(ACCESS_HEADS in access)	//Hispania changes start & end here
 			authenticated = COMM_AUTHENTICATION_CAPT
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id = H.get_idcard(TRUE)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -126,7 +126,7 @@
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id/I = H.get_idcard(TRUE)
 			if(istype(I))
-				if(ACCESS_CAPTAIN in I.access)
+				if(ACCESS_HEADS in I.access)	//Hispania changes start & end here
 					change_security_level(text2num(params["level"]))
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this.</span>")


### PR DESCRIPTION
Portea este PR

https://github.com/Helixis/Paradise/pull/53

El problema esq hubo cambios en toda la interfaz por incorporacion de TGUI  y ya no es tan simple como cambiar una linea... Ahora asi funciona que los heads tambien pueden enviar un mensaje a centcomm o pedir los codigos de la nuke. Tampoco lo veo tan mal 