### PR TITLE
Habilita los secBorgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -336,10 +336,10 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		"Janitor" = image('icons/mob/robots.dmi', "jan-radial"),
 		"Medical" = image('icons/mob/robots.dmi', "med-radial"),
 		"Mining" = image('icons/mob/robots.dmi', "mining-radial"),
-		"Service" = image('icons/mob/robots.dmi', "serv-radial"))
+		"Service" = image('icons/mob/robots.dmi', "serv-radial"),
+		"Security" = image('icons/mob/robots.dmi', "security-radial"))//hispania changes start & end here
 	var/static/list/special_modules = list(
 		"Combat" = image('icons/mob/robots.dmi', "security-radial"),
-		"Security" = image('icons/mob/robots.dmi', "security-radial"),
 		"Destroyer" = image('icons/mob/robots.dmi', "droidcombat"))
 
 	if(mmi?.alien)


### PR DESCRIPTION
Esto surgio a raiz de una charla en discord sobre la necesidad de añadir mas seguridad a la estacion. La idea es promover que haya mas gente en este puesto y los antags deban ser mas sigilosos si quieren tener exito en sus objetivos. Actualmente los sec borgs con los nerfs de velocidad no son la misma amenaza que antes suponian para los antags.  Facilmente se pueden ir corriendo. A menos que tenga mejoras VTEC claro

![image](https://user-images.githubusercontent.com/24284918/217408552-5aeebc55-b71c-424b-8e23-39f8221ff130.png)
![image](https://user-images.githubusercontent.com/24284918/217408556-8e372972-cb3b-4b3f-a127-10488366b6af.png)
