### PR TITLE
Quita cyberiad.dmm de votacion de mapa

### DIFF
--- a/code/modules/mapping/cyberiad.dm
+++ b/code/modules/mapping/cyberiad.dm
@@ -3,3 +3,4 @@
 	technical_name = "Cyberiad"
 	map_path = "_maps/map_files/cyberiad/cyberiad.dmm"
 	webmap_url = "https://affectedarc07.github.io/SS13WebMap/Paradise/Cyberiad/"
+	voteable = FALSE


### PR DESCRIPTION
Quita la cyberiad de paradise de las votaciones,  si quieren puede dejarse. Pero no le veo mucho sentido francamente